### PR TITLE
Multiple quality improvements - squid:CommentedOutCodeLine, squid:S18…

### DIFF
--- a/src/main/java/cc/aicode/e2e/exception/ExcelContentInvalidException.java
+++ b/src/main/java/cc/aicode/e2e/exception/ExcelContentInvalidException.java
@@ -6,7 +6,7 @@ package cc.aicode.e2e.exception;
  */
 public class ExcelContentInvalidException extends Exception {
     private static final long serialVersionUID = 1L;
-    private String message = null;
+    private String message;
 
     public ExcelContentInvalidException(Exception e) {
         initCause(e);

--- a/src/main/java/cc/aicode/e2e/exception/ExcelParseException.java
+++ b/src/main/java/cc/aicode/e2e/exception/ExcelParseException.java
@@ -5,7 +5,7 @@ package cc.aicode.e2e.exception;
  */
 public class ExcelParseException extends Exception {
     private static final long serialVersionUID = 1L;
-    private String message = null;
+    private String message;
 
     public ExcelParseException(Exception e) {
         initCause(e);

--- a/src/test/java/cc/aicode/e2e/Excel2Entity/MyDataType.java
+++ b/src/test/java/cc/aicode/e2e/Excel2Entity/MyDataType.java
@@ -3,7 +3,7 @@ package cc.aicode.e2e.Excel2Entity;
 import cc.aicode.e2e.extension.ExcelType;
 
 public class MyDataType extends ExcelType<MyDataType> {
-    private String value = null;
+    private String value;
 
     @Override
     public MyDataType parseValue(String value) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:CommentedOutCodeLine - Sections of code should not be "commented out"
squid:S1854 - Dead stores should be removed
squid:S1941 - Variables should not be declared before they are relevant
squid:S2325 - "private" methods that don't access instance data should be "static"
squid:S3052 - Fields should not be initialized to default values

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1854
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1941
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325
https://dev.eclipse.org/sonar/coding_rules#q=squid:S3052

Please let me know if you have any questions.

M-Ezzat
